### PR TITLE
[geoclue] Close client interfaces when no longer used.

### DIFF
--- a/geoclue/src/master-provider.c
+++ b/geoclue/src/master-provider.c
@@ -1064,13 +1064,12 @@ gc_master_provider_unsubscribe (GcMasterProvider *provider,
 		priv->address_clients = g_list_remove (priv->address_clients, client);
 	}
 	
-	if (!priv->position_clients &&
-	    !priv->address_clients) {
-		/* no one is using this provider, shutdown... */
+	if ((!priv->position_clients && !priv->address_clients) && (priv->position || priv->address)) {
+		/* no one is using this provider and it is initialized, shutdown... */
 		/* not clearing cached accuracies on purpose */
 		g_debug ("%s without clients", priv->name);
 		
-		/* gc_master_provider_deinitialize (provider); */
+		gc_master_provider_deinitialize (provider);
 	}
 }
 


### PR DESCRIPTION
Geoclue was not tracking usage of the master clients,
/org/freedesktop/Geoclue/Master/client?. They were not being cleaned up
after the application that was using them exited. This was keeping all
active providers used by the client running. Usage of master clients
are now tracked and they are destroyed when no longer used.

Master clients no longer unsubscribe from master providers when no
matching available providers are found.

Deinitialize master provider when it is no longer used by any clients.

These changes cause all references to the Geoclue providers to be
closed, allowing the providers to terminate when no longer required.

This change does not cause geoclue-master to terminate.

Based on the patch from https://bugs.freedesktop.org/show_bug.cgi?id=14993
