### PR TITLE
[geoclue] Clean up master client private on dispose/finialize.

### DIFF
--- a/geoclue/geoclue/geoclue-master-client.c
+++ b/geoclue/geoclue/geoclue-master-client.c
@@ -111,12 +111,18 @@ typedef struct _GeoclueMasterClientAsyncData {
 static void
 finalize (GObject *object)
 {
+	GeoclueMasterClientPrivate *priv = GET_PRIVATE(object);
+	g_free(priv->object_path);
+
 	G_OBJECT_CLASS (geoclue_master_client_parent_class)->finalize (object);
 }
 
 static void
 dispose (GObject *object)
 {
+	GeoclueMasterClientPrivate *priv = GET_PRIVATE(object);
+	g_object_unref(priv->proxy);
+	priv->proxy = 0;
 
 	G_OBJECT_CLASS (geoclue_master_client_parent_class)->dispose (object);
 }


### PR DESCRIPTION
Private data of the master client object was not being cleaned up on
destruction. Resulting in memory leaks. Worse still, the DBus proxy
object was still valid and emitting signals in response to DBus
messages causing access to freed master client object.
