### PR TITLE
[geoclue] Don't build with Connman support. Fixes JB#24172

### DIFF
--- a/rpm/geoclue.spec
+++ b/rpm/geoclue.spec
@@ -176,7 +176,7 @@ Group: System/Libraries
 
 %build
 autoreconf -vfi
-%configure --enable-static=no --enable-connman=yes
+%configure --enable-static=no --enable-connman=no
 make %{?_smp_mflags}
 
 


### PR DESCRIPTION
Connman support in Geoclue uses the old org.moblin.connman DBus service
which has a different API to the newer net.connman DBus service.
Disable Connman support. This has no functional change as the
org.moblin.connman service is not available.
